### PR TITLE
Fix member permission inheritance joins

### DIFF
--- a/src/XperienceCommunity.MemberRoles/Repositories/Implementation/MemberAuthorizationFilterAndPermissionSummaryRepository.cs
+++ b/src/XperienceCommunity.MemberRoles/Repositories/Implementation/MemberAuthorizationFilterAndPermissionSummaryRepository.cs
@@ -160,7 +160,7 @@ namespace XperienceCommunity.MemberRoles.Repositories.Implementation
                 var webPageTableJoinItems = new List<string>();
                 for (var i = 1; i <= webPageMaxDepth; i++) {
                     webPagePermissionSettingCoalesceItems.Add($"MPS{i}.WebPageItemMemberPermissionSettingID");
-                    webPageTableJoinItems.Add($"left join CMS_WebPageItem as WP{i} on WP{i - 1}.WebPageItemParentID = WP{i}.WebPageItemID left join XperienceCommunity_WebPageItemMemberPermissionSetting as MPS{i} on WP{i}.WebPageItemID = MPS{i}.WebPageItemMemberPermissionSettingWebPageItemID and MPS{1}.WebPageItemMemberPermissionSettingBreakInheritance = 1");
+                    webPageTableJoinItems.Add($"left join CMS_WebPageItem as WP{i} on WP{i - 1}.WebPageItemParentID = WP{i}.WebPageItemID left join XperienceCommunity_WebPageItemMemberPermissionSetting as MPS{i} on WP{i}.WebPageItemID = MPS{i}.WebPageItemMemberPermissionSettingWebPageItemID and MPS{i}.WebPageItemMemberPermissionSettingBreakInheritance = 1");
                 }
                 // First join is different format
                 webPageTableJoinItems.RemoveAt(0);
@@ -169,7 +169,7 @@ namespace XperienceCommunity.MemberRoles.Repositories.Implementation
                 var folderTableJoinItems = new List<string>();
                 for (var i = 1; i <= folderMaxDepth; i++) {
                     folderPermissionSettingCoalesceItems.Add($"CFS{i}.ContentFolderMemberPermissionSettingID");
-                    folderTableJoinItems.Add($"left join CMS_ContentFolder as CF{i} on CF{i - 1}.ContentFolderParentFolderID = CF{i}.ContentFolderID left join XperienceCommunity_ContentFolderMemberPermissionSetting as CFS{i} on CF{i}.ContentFolderID = CFS{i}.ContentFolderMemberPermissionContentFolderID and CFS{1}.ContentFolderMemberPermissionSettingBreakInheritance = 1");
+                    folderTableJoinItems.Add($"left join CMS_ContentFolder as CF{i} on CF{i - 1}.ContentFolderParentFolderID = CF{i}.ContentFolderID left join XperienceCommunity_ContentFolderMemberPermissionSetting as CFS{i} on CF{i}.ContentFolderID = CFS{i}.ContentFolderMemberPermissionContentFolderID and CFS{i}.ContentFolderMemberPermissionSettingBreakInheritance = 1");
                 }
                 // First join is different format
                 folderTableJoinItems.RemoveAt(0);


### PR DESCRIPTION
### Problem

Permissions applied on **ancestor folders or pages** (e.g. `MyFolder`) were not being respected for content items located in **descendant folders** (`Subfolder`).
This caused `RemoveUnauthorizedItems` to skip filtering correctly unless the permission was explicitly set on the immediate folder.

The issue was caused by the dynamic SQL builder in
`MemberAuthorizationFilterAndPermissionSummaryRepository`,
which hardcoded the first-level alias (`CFS1` / `MPS1`) when checking
`BreakInheritance = 1` in all ancestor joins.
As a result, higher-level folder/page permissions were ignored.

---

### Solution

Updated the dynamic join generation to use the correct loop alias (`CFS{i}` / `MPS{i}`) for each level.
Now each ancestor’s own `BreakInheritance` flag is evaluated correctly, ensuring permission inheritance works as intended for nested folders and pages.

---

### Verification

* Set permissions on a parent folder (`MyFolder`) only.
* Place content in a descendant folder (`Subfolder`).
* Call `RemoveUnauthorizedItems` — content is now correctly filtered.

I ran some quick tests and it seems to work correctly, but I’m not sure all cases are covered.
It would be great if you could also run some checks on your side — thanks!
